### PR TITLE
Handle IPv6 host addresses

### DIFF
--- a/easykube/kubernetes/config.py
+++ b/easykube/kubernetes/config.py
@@ -1,4 +1,5 @@
 import atexit
+import ipaddress
 import base64
 import os
 import pathlib
@@ -145,6 +146,8 @@ class Configuration:
         server_port = os.environ.get(cls.SA_PORT_ENV_NAME)
         if not server_host or not server_port:
             raise ConfigurationError("Server host/port not configured")
+        if ipaddress.ip_address(server_host).version == 6:
+            server_host = f"[{server_host}]"
         kwargs.setdefault("base_url", f"https://{server_host}:{server_port}")
         # Check if the certificate file exists
         if os.path.isfile(cls.SA_CERT_FILENAME):


### PR DESCRIPTION
When the `KUBERNETES_SERVICE_HOST` env var inside a pod is an IPv6 address we get errors such as
```
  File "/venv/lib/python3.10/site-packages/capi_janitor/openstack/operator.py", line 18, in <module>
    ekclient = ekconfig.async_client()
  File "/venv/lib/python3.10/site-packages/easykube/kubernetes/config.py", line 67, in async_client
    return AsyncClient(**merged)
  File "/venv/lib/python3.10/site-packages/easykube/kubernetes/client/client.py", line 22, in __init__
    super().__init__(**kwargs)
  File "/venv/lib/python3.10/site-packages/easykube/rest/client.py", line 18, in __init__
    super().__init__(**kwargs)
  File "/venv/lib/python3.10/site-packages/httpx/_client.py", line 1378, in __init__
    super().__init__(
  File "/venv/lib/python3.10/site-packages/httpx/_client.py", line 206, in __init__
    self._base_url = self._enforce_trailing_slash(URL(base_url))
  File "/venv/lib/python3.10/site-packages/httpx/_urls.py", line 117, in __init__
    self._uri_reference = urlparse(url, **kwargs)
  File "/venv/lib/python3.10/site-packages/httpx/_urlparse.py", line 321, in urlparse
    parsed_port: int | None = normalize_port(port, scheme)
  File "/venv/lib/python3.10/site-packages/httpx/_urlparse.py", line 411, in normalize_port
    raise InvalidURL(f"Invalid port: {port!r}")
httpx.InvalidURL: Invalid port: 'cafe:43::1:443'
```
which can be fixed by wrapping the IPv6 address in square brackets.